### PR TITLE
Proper install support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -87,4 +87,5 @@ jobs:
       run: |
         spack -e . mirror set --push --oci-username ${{ github.actor }} --oci-password "${{ secrets.GITHUB_TOKEN }}" local-buildcache
         spack -e . buildcache push --base-image ubuntu:24.04 --update-index local-buildcache
-      if: ${{ !cancelled() }}
+      # The owner must match the namespace in /spack-repo/environments/ci_env_settings.yaml.tpl
+      if: ${{ !cancelled() && github.repository_owner == 'constracktor' }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,10 +60,9 @@ jobs:
         CC: gcc-14
         CXX: g++-14
       shell: spack-bash {0}
-      # TODO: we shouldn't have to set the prefix here!
       run: |
         spack env activate .
-        cmake "--preset=ci-${{ matrix.os }}" -DCMAKE_INSTALL_PREFIX=prefix
+        cmake "--preset=ci-${{ matrix.os }}"
 
     - name: Build
       run: cmake --build build --config RelWithDebInfo -j 2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,7 +3,6 @@ name: Continuous Integration
 on:
   push:
     branches:
-    - main
 
   pull_request:
     branches:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,14 +65,14 @@ jobs:
         cmake "--preset=ci-${{ matrix.os }}"
 
     - name: Build
-      run: cmake --build build --config RelWithDebInfo -j 2
+      run: cmake --build build --config Release -j 2
 
     - name: Install
-      run: cmake --install build --config RelWithDebInfo --prefix prefix
+      run: cmake --install build --config Release --prefix prefix
 
     - name: Test
       working-directory: build
-      run: ctest --output-on-failure --no-tests=ignore -C RelWithDebInfo -j 2
+      run: ctest --output-on-failure --no-tests=ignore -C Release -j 2
 
     - name: Upload
       uses: actions/upload-artifact@v4
@@ -80,6 +80,18 @@ jobs:
         name: binaries-${{ matrix.os }}
         path: |
           prefix/
+
+    - name: Configure example project
+      env:
+        CC: gcc-14
+        CXX: g++-14
+      shell: spack-bash {0}
+      run: |
+        spack env activate .
+        cmake -G "Unix Makefiles" -S examples/gprat_cpp -B build_examples -DCMAKE_BUILD_TYPE=Release -DCMAKE_PREFIX_PATH=$PWD/prefix
+
+    - name: Build example project
+      run: cmake --build build_examples --config Release -j 2
 
     # See: https://github.com/spack/setup-spack?tab=readme-ov-file#example-caching-your-own-binaries-for-public-repositories
     - name: Push packages and update index

--- a/.gitignore
+++ b/.gitignore
@@ -192,7 +192,7 @@ cython_debug/
 
 # Datafiles
 examples/*/output.csv
-examples/gprat_*/install/
+examples/gprat_*/include/
 /.vscode
 
 # Editor related files

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,8 +1,11 @@
-message(STATUS "Building Python language bindings for GPRat.")
+cmake_minimum_required(VERSION 3.23)
 
-cmake_minimum_required(VERSION 3.16)
-
-project(gprat)
+project(
+  GPRat
+  VERSION 0.1.0
+  DESCRIPTION "Leveraging HPX for Gaussian Processes in Python"
+  HOMEPAGE_URL "https://github.com/constracktor/GPRat"
+  LANGUAGES CXX)
 
 include(CMakeDependentOption)
 
@@ -27,6 +30,13 @@ if(GPRAT_ENABLE_FORMAT_TARGETS)
   endif()
 endif()
 
+if(NOT CMAKE_SKIP_INSTALL_RULES)
+  # Our installs follow the standard GNU directory layout. This include needs to
+  # come first since we need the CMAKE_INSTALL_* in the CMakeLists.txt of each
+  # target.
+  include(GNUInstallDirs)
+endif()
+
 if(GPRAT_BUILD_CORE)
   set(MKL_INTERFACE_FULL "intel_lp64")
   set(MKL_THREADING "sequential")
@@ -37,5 +47,44 @@ if(GPRAT_BUILD_CORE)
   add_subdirectory(core)
   if(GPRAT_BUILD_BINDINGS)
     add_subdirectory(bindings)
+  endif()
+endif()
+
+if(NOT CMAKE_SKIP_INSTALL_RULES AND GPRAT_BUILD_CORE)
+  include(CMakePackageConfigHelpers)
+
+  # find_package(<package>) call for consumers to find this project
+  set(package GPRat)
+
+  write_basic_package_version_file("${package}ConfigVersion.cmake"
+                                   COMPATIBILITY SameMajorVersion)
+
+  # Allow package maintainers to freely override the path for the configs
+  set(GPRat_INSTALL_CMAKEDIR
+      "${CMAKE_INSTALL_LIBDIR}/cmake/${package}"
+      CACHE STRING
+            "CMake package config location relative to the install prefix")
+  set_property(CACHE GPRat_INSTALL_CMAKEDIR PROPERTY TYPE PATH)
+  mark_as_advanced(GPRat_INSTALL_CMAKEDIR)
+
+  install(
+    FILES cmake/install-config.cmake
+    DESTINATION "${GPRat_INSTALL_CMAKEDIR}"
+    RENAME "${package}Config.cmake"
+    COMPONENT Development)
+
+  install(
+    FILES "${PROJECT_BINARY_DIR}/${package}ConfigVersion.cmake"
+    DESTINATION "${GPRat_INSTALL_CMAKEDIR}"
+    COMPONENT Development)
+
+  install(
+    EXPORT GPRatTargets
+    NAMESPACE GPRat::
+    DESTINATION "${GPRat_INSTALL_CMAKEDIR}"
+    COMPONENT Development)
+
+  if(PROJECT_IS_TOP_LEVEL)
+    include(CPack)
   endif()
 endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,7 +3,7 @@ cmake_minimum_required(VERSION 3.23)
 project(
   GPRat
   VERSION 0.1.0
-  DESCRIPTION "Leveraging HPX for Gaussian Processes in Python"
+  DESCRIPTION "Gaussian Process Regression using Asynchronous Tasks"
   HOMEPAGE_URL "https://github.com/constracktor/GPRat"
   LANGUAGES CXX)
 
@@ -13,6 +13,9 @@ include(CMakeDependentOption)
 option(GPRAT_BUILD_CORE "Build the core library" ON)
 cmake_dependent_option(GPRAT_BUILD_BINDINGS "Build the Python bindings" ON
                        "GPRAT_BUILD_CORE" OFF)
+cmake_dependent_option(
+  GPRAT_ENABLE_EXAMPLES "Build example applications as well?" ON
+  "GPRAT_BUILD_CORE" OFF)
 
 option(GPRAT_ENABLE_FORMAT_TARGETS "Enable clang-format / cmake-format targets"
        ${PROJECT_IS_TOP_LEVEL})
@@ -87,4 +90,8 @@ if(NOT CMAKE_SKIP_INSTALL_RULES AND GPRAT_BUILD_CORE)
   if(PROJECT_IS_TOP_LEVEL)
     include(CPack)
   endif()
+endif()
+
+if(GPRAT_ENABLE_EXAMPLES)
+  add_subdirectory(examples/gprat_cpp)
 endif()

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -166,7 +166,7 @@
       "binaryDir": "${sourceDir}/build/release-linux",
       "inherits": ["ci-linux"],
       "cacheVariables": {
-        "CMAKE_BUILD_TYPE": "RelWithDebInfo",
+        "CMAKE_BUILD_TYPE": "Release",
         "CMAKE_EXPORT_COMPILE_COMMANDS": "ON"
       }
     }
@@ -180,7 +180,7 @@
     {
       "name": "release-linux",
       "configurePreset": "release-linux",
-      "configuration": "RelWithDebInfo"
+      "configuration": "Release"
     }
   ],
   "testPresets": [

--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ The following options can be set to include / exclude parts of the project:
 | GPRAT_BUILD_CORE            | Enable/Disable building of the core library    | ON              |
 | GPRAT_BUILD_BINDINGS        | Enable/Disable building of the Python bindings | ON              |
 | GPRAT_ENABLE_FORMAT_TARGETS | Enable/disable code formatting helper targets  | ON if top-level |
+| GPRAT_ENABLE_EXAMPLES       | Enable/disable example projects                | ON if top-level |
 
 Respective scripts can be found in this directory.
 
@@ -53,7 +54,9 @@ reference implementations based on TensorFlow
 
 - Go to [`examples/gprat_cpp`](examples/gprat_cpp/)
 - Set parameters in [`execute.cpp`](examples/gprat_cpp/src/execute.cpp)
-- Run `./run_gprat_cpp.sh` to build and run example
+- The example is built as part of the main project.
+  If you want to use an installed GPrat version:
+  Run `./run_gprat_cpp.sh` to build and run example
 
 ### To run GPRat with Python
 

--- a/bindings/CMakeLists.txt
+++ b/bindings/CMakeLists.txt
@@ -25,8 +25,28 @@ source_group("Source Files" FILES ${SOURCE_FILES})
 source_group("Header Files" FILES ${HEADER_FILES})
 
 pybind11_add_module(gprat_bindings ${SOURCE_FILES} ${HEADER_FILES})
-# must match the Python module name!
-set_target_properties(gprat_bindings PROPERTIES OUTPUT_NAME "gprat")
 
-install(TARGETS gprat_bindings DESTINATION "${CMAKE_INSTALL_PREFIX}")
+# must match the Python module name!
+set_property(TARGET gprat_bindings PROPERTY OUTPUT_NAME "gprat")
+
+# We'd like to consume it just as `bindings` under the GPRat namespace
+set_property(TARGET gprat_bindings PROPERTY EXPORT_NAME bindings)
+add_library(GPRat::bindings ALIAS gprat_bindings)
+
 target_link_libraries(gprat_bindings PUBLIC GPRat::core)
+
+if(NOT CMAKE_SKIP_INSTALL_RULES)
+  install(
+    TARGETS gprat_bindings
+    EXPORT GPRatTargets
+    RUNTIME COMPONENT Runtime
+    LIBRARY COMPONENT Runtime NAMELINK_COMPONENT Development
+    ARCHIVE COMPONENT Development
+    INCLUDES
+    DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}"
+    # XXX: Due to pybind11_add_module() CMake doesn't use the defaults from
+    # GNUInstallDirs, forcing us to write these out.
+    ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
+    LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
+    RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR})
+endif()

--- a/cmake/install-config.cmake
+++ b/cmake/install-config.cmake
@@ -1,0 +1,8 @@
+# Same as in the root CMakeLists.txt
+set(MKL_INTERFACE_FULL "intel_lp64")
+set(MKL_THREADING "sequential")
+
+find_package(HPX REQUIRED)
+find_package(MKL CONFIG REQUIRED)
+
+include("${CMAKE_CURRENT_LIST_DIR}/GPRatTargets.cmake")

--- a/compile_gprat.sh
+++ b/compile_gprat.sh
@@ -8,21 +8,11 @@ set -e  # Exit immediately if a command exits with a non-zero status.
 # Configurations
 ################################################################################
 # Load GCC compiler
-module load gcc/13.2.0
-export CC=gcc
-export CXX=g++
+spack load gcc@14.2.0
+spack load cmake
+
 # Activate spack environment
 spack env activate gprat_cpu_gcc
-
-# # Load Clang compiler
-# module load clang/17.0.1
-# export CC=clang
-# export CXX=clang++
-# # Activate spack environment
-# spack env activate gprat_gpu_clang
-
-# Configure APEX
-#export APEX_SCREEN_OUTPUT=1
 
 # Bindings
 if [[ "$1" == "python" ]]

--- a/core/CMakeLists.txt
+++ b/core/CMakeLists.txt
@@ -9,6 +9,8 @@ add_library(
   src/gp_uncertainty.cpp
   src/utils_c.cpp)
 
+# We'd like to consume it just as core under the GPRat namespace
+set_property(TARGET gprat_core PROPERTY EXPORT_NAME core)
 add_library(GPRat::core ALIAS gprat_core)
 
 # Add them as PRIVATE sources here so they show up in project files Can't use
@@ -29,7 +31,20 @@ target_compile_features(gprat_core PUBLIC cxx_std_17)
 
 set_property(TARGET gprat_core PROPERTY POSITION_INDEPENDENT_CODE ON)
 
-install(TARGETS gprat_core DESTINATION "${CMAKE_INSTALL_PREFIX}/install/lib")
+if(NOT CMAKE_SKIP_INSTALL_RULES)
+  # We need to manually install those into CMAKE_INSTALL_INCLUDEDIR. Below
+  # install(TARGETS ...) only setups the paths for the exported targets.
+  install(
+    DIRECTORY include/
+    DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}"
+    COMPONENT Development)
 
-install(DIRECTORY include/
-        DESTINATION "${CMAKE_INSTALL_PREFIX}/install/include")
+  install(
+    TARGETS gprat_core
+    EXPORT GPRatTargets
+    RUNTIME COMPONENT Runtime
+    LIBRARY COMPONENT Runtime NAMELINK_COMPONENT Development
+    ARCHIVE COMPONENT Development
+    INCLUDES
+    DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}")
+endif()

--- a/examples/gprat_cpp/CMakeLists.txt
+++ b/examples/gprat_cpp/CMakeLists.txt
@@ -1,38 +1,20 @@
 cmake_minimum_required(VERSION 3.16)
 
-project(example_cpp)
+project(gprat_cpp)
 
-# Set C++ standard
-set(CMAKE_CXX_STANDARD 17)
-set(CMAKE_CXX_STANDARD_REQUIRED ON)
-set(CMAKE_CXX_EXTENSIONS OFF)
-
-# Find HPX
-find_package(HPX REQUIRED)
-find_package(MKL CONFIG REQUIRED)
-
-# Include directories
-include_directories(${HPX_INCLUDE_DIR})
-include_directories(${MKL_INCLUDE_DIRS})
-
-# Determine the path to the include directory
-get_filename_component(INCLUDE_DIR "install/include" ABSOLUTE)
-# Add the include directory
-include_directories(${INCLUDE_DIR})
-
-# Set the output directory for executables
-set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR})
-
-# Determine the path to the library directory relative to the current
-# CMakeLists.txt file
-get_filename_component(LIB_DIR "install/lib" ABSOLUTE)
-# Find the Gaussian Process library
-find_library(GPRAT_LIB gprat_core HINTS ${LIB_DIR} REQUIRED)
-message(STATUS "GPRat core library found: ${GPRAT_LIB}")
+# This project can be built as part of GPRat itself or as a standalone project
+# in which case below find_package() call is used.
+if(TARGET GPRat::core)
+  message("Using in-tree GPRat::core")
+else()
+  message("Using out-of-tree GPRat::core")
+  find_package(GPRat REQUIRED)
+endif()
 
 # Add the executable
 add_executable(gprat_cpp src/execute.cpp)
+
+target_compile_features(gprat_cpp PUBLIC cxx_std_17)
+
 # Link the libraries
-target_link_libraries(
-  gprat_cpp PUBLIC "${GPRAT_LIB}" HPX::hpx MKL::mkl_intel_lp64 MKL::mkl_core
-                   MKL::MKL MKL::mkl_sequential)
+target_link_libraries(gprat_cpp PUBLIC GPRat::core)

--- a/examples/gprat_cpp/run_gprat_cpp.sh
+++ b/examples/gprat_cpp/run_gprat_cpp.sh
@@ -22,7 +22,7 @@ export APEX_DISABLE=1
 ################################################################################
 rm -rf build && mkdir build && cd build
 # Configure the project
-cmake .. -DCMAKE_BUILD_TYPE=Release -DHPX_IGNORE_BOOST_COMPATIBILITY=ON
+cmake .. -DCMAKE_BUILD_TYPE=Release -DGPRat_DIR=./lib/cmake/GPRat
  # Build the project
 make -j
 

--- a/examples/gprat_cpp/run_gprat_cpp.sh
+++ b/examples/gprat_cpp/run_gprat_cpp.sh
@@ -7,15 +7,11 @@ set -e  # Exit immediately if a command exits with a non-zero status.
 # Configurations
 ################################################################################
 # Load GCC compiler
-module load gcc/13.2.0
-#module load cmake
-export CC=gcc
-export CXX=g++
+spack load gcc@14.2.0
+spack load cmake
 
-# # Load Clang compiler
-# module load clang/17.0.1
-# export CC=clang
-# export CXX=clang++
+# Activate environment
+spack env activate gprat_cpu_gcc
 
 # Configure APEX
 export APEX_SCREEN_OUTPUT=0
@@ -27,8 +23,8 @@ export APEX_DISABLE=1
 rm -rf build && mkdir build && cd build
 # Configure the project
 cmake .. -DCMAKE_BUILD_TYPE=Release -DHPX_IGNORE_BOOST_COMPATIBILITY=ON
-# Build the project
-make -j VERBOSE=1 all
+ # Build the project
+make -j
 
 ################################################################################
 # Run code

--- a/examples/gprat_cpp/run_gprat_cpp.sh
+++ b/examples/gprat_cpp/run_gprat_cpp.sh
@@ -20,18 +20,14 @@ export CXX=g++
 # Configure APEX
 export APEX_SCREEN_OUTPUT=0
 export APEX_DISABLE=1
-# Configure MKL
-export MKL_CONFIG='-DMKL_ARCH=intel64 -DMKL_LINK=dynamic -DMKL_INTERFACE_FULL=intel_lp64 -DMKL_THREADING=sequential'
 
 ################################################################################
 # Compile code
 ################################################################################
 rm -rf build && mkdir build && cd build
 # Configure the project
-cmake .. -DCMAKE_BUILD_TYPE=Release \
-	 -DHPX_IGNORE_BOOST_COMPATIBILITY=ON \
-	 $MKL_CONFIG
- # Build the project
+cmake .. -DCMAKE_BUILD_TYPE=Release -DHPX_IGNORE_BOOST_COMPATIBILITY=ON
+# Build the project
 make -j VERBOSE=1 all
 
 ################################################################################

--- a/examples/gprat_cpp/src/execute.cpp
+++ b/examples/gprat_cpp/src/execute.cpp
@@ -1,5 +1,5 @@
-#include "../install/include/gprat_c.hpp"
-#include "../install/include/utils_c.hpp"
+#include "gprat_c.hpp"
+#include "utils_c.hpp"
 #include <chrono>
 #include <fstream>
 #include <iostream>

--- a/examples/gprat_cpp/src/execute.cpp
+++ b/examples/gprat_cpp/src/execute.cpp
@@ -8,22 +8,22 @@ int main(int argc, char *argv[])
 {
     /////////////////////
     /////// configuration
-    int START = 1024;
-    int END = 1024;
-    int STEP = 128;
-    int LOOP = 1;
-    const int OPT_ITER = 1;
+    std::size_t START = 1024;
+    std::size_t END = 1024;
+    std::size_t STEP = 128;
+    std::size_t LOOP = 1;
+    const std::size_t OPT_ITER = 1;
 
     int n_test = 1024;
     const std::size_t N_CORES = 2;  // Set this to the number of threads
-    const int n_tiles = 32;
-    const int n_reg = 128;
+    const std::size_t n_tiles = 32;
+    const std::size_t n_reg = 128;
 
     std::string train_path = "../../../data/training/training_input.txt";
     std::string out_path = "../../../data/training/training_output.txt";
     std::string test_path = "../../../data/test/test_input.txt";
 
-    for (std::size_t core = 2; core <= pow(2, N_CORES); core = core * 2)
+    for (std::size_t core = 2; core <= static_cast<std::size_t>(pow(2, N_CORES)); core = core * 2)
     {
         // Create new argc and argv to include the --hpx:threads argument
         std::vector<std::string> args(argv, argv + argc);
@@ -41,7 +41,7 @@ int main(int argc, char *argv[])
 
         for (std::size_t start = START; start <= END; start = start + STEP)
         {
-            int n_train = start;
+            int n_train = static_cast<int>(start);
             for (std::size_t l = 0; l < LOOP; l++)
             {
                 auto start_total = std::chrono::high_resolution_clock::now();
@@ -73,13 +73,13 @@ int main(int argc, char *argv[])
 
                 // Measure the time taken to execute gp.cholesky();
                 auto start_cholesky = std::chrono::high_resolution_clock::now();
-                // std::vector<std::vector<double>> choleksy = gp.cholesky();
+                std::vector<std::vector<double>> choleksy = gp.cholesky();
                 auto end_cholesky = std::chrono::high_resolution_clock::now();
-                std::chrono::duration<double> cholesky_time = end_cholesky - end_cholesky;
+                std::chrono::duration<double> cholesky_time = end_cholesky - start_cholesky;
 
                 // Measure the time taken to execute gp.optimize(hpar);
                 auto start_opt = std::chrono::high_resolution_clock::now();
-                // std::vector<double> losses = gp.optimize(hpar);
+                std::vector<double> losses = gp.optimize(hpar);
                 auto end_opt = std::chrono::high_resolution_clock::now();
                 std::chrono::duration<double> opt_time = end_opt - start_opt;
 

--- a/examples/gprat_python/execute.py
+++ b/examples/gprat_python/execute.py
@@ -6,7 +6,7 @@ from csv import writer
 from config import get_config
 from hpx_logger import setup_logging
 
-import gprat
+import lib.gprat as gprat
 
 logger = logging.getLogger()
 log_filename = "./hpx_logs.log"

--- a/examples/gprat_python/run_gprat_python.sh
+++ b/examples/gprat_python/run_gprat_python.sh
@@ -1,4 +1,2 @@
 #!/bin/bash
-module load gcc/13.2.0
-
 python3 execute.py

--- a/spack-repo/environments/setup_gprat_cpu_gcc.sh
+++ b/spack-repo/environments/setup_gprat_cpu_gcc.sh
@@ -1,17 +1,16 @@
 #!/usr/bin/env bash
-# Script to setup CPU spack environment for GPRat on simcl1n1-4
+# Script to setup CPU spack environment for GPRat using a recent gcc
 set -e
-# create environment and copy config file
-spack env create gprat_cpu_gcc
-cp spack_cpu_gcc.yaml $HOME/spack/var/spack/environments/gprat_cpu_gcc/spack.yaml
-spack env activate gprat_cpu_gcc
-# find external compiler
-module load gcc/13.2.0
+# search for gcc compiler and install if necessary
 spack compiler find
-# find external packages
-#spack external find
+spack install gcc@14.2.0
+# create environment and copy config file
+export ENV_NAME=gprat_cpu_gcc
+spack env create $ENV_NAME
+cp spack_cpu_gcc.yaml $HOME/spack/var/spack/environments/$ENV_NAME/spack.yaml
+spack env activate $ENV_NAME
+# use external python
 spack external find python
-spack external find ninja
 # setup environment
 spack concretize -f
 spack install

--- a/spack-repo/environments/spack_cpu_gcc.yaml
+++ b/spack-repo/environments/spack_cpu_gcc.yaml
@@ -1,8 +1,7 @@
 spack:
   specs:
-    #- hpx@1.10.0%gcc networking=none max_cpu_count=256 instrumentation=apex ^cmake@3.30 ^curl@8.10.1 ^ninja@1.12.1
   - hpx@1.10.0%gcc +static malloc=system networking=none max_cpu_count=256 instrumentation=none ^cmake@3.30 ^curl@8.10.1 ^ninja@1.12.1
-  - intel-oneapi-mkl@2024.2.1%gcc
+  - intel-oneapi-mkl@2024.2.1%gcc shared=false
   view: true
   concretizer:
     unify: true


### PR DESCRIPTION
* Follow the standard GNU layout (/include, /lib, ...)
* Export `*Config.cmake` files so users can just call `find_package(GPXPy)`
* Test install support in CI Pipeline (via example project)